### PR TITLE
Feature: model evaluation

### DIFF
--- a/ragatouille/RAGPretrainedModel.py
+++ b/ragatouille/RAGPretrainedModel.py
@@ -424,7 +424,7 @@ class RAGPretrainedModel:
     def evaluate(
         self,
         queries: list[str],
-        expected_ids: list[list[str]],
+        expected_ids: list[list[tuple[str, Optional[int]]]],
         metrics: list[str] = None,
         k: list[int] = None,
     ) -> dict[str, dict[int, float]]:
@@ -432,7 +432,7 @@ class RAGPretrainedModel:
 
         Parameters:
             queries (list[str]): A list of queries to evaluate the model on.
-            expected_ids (list[list[str]]): A list of lists of expected document IDs for each query.
+            expected_ids (list[list[tuple[str, Optional[int]]]): A list of lists of expected (document_id, passage_id) tuples for each query. Set passage_id to None if not applicable.
             metrics (list[str]): A list of metrics to evaluate the model on. Valid metrics are "hit_rate", "recall", and "mrr".
             k (list[int]): The numbers of results to consider for each query in the evaluation.
 

--- a/ragatouille/RAGPretrainedModel.py
+++ b/ragatouille/RAGPretrainedModel.py
@@ -424,7 +424,8 @@ class RAGPretrainedModel:
     def evaluate(
         self,
         queries: list[str],
-        expected_ids: list[list[tuple[str, Optional[int]]]],
+        expected_document_ids: list[list[str]],
+        expected_passage_ids: list[list[int]] = None,
         metrics: list[str] = None,
         k: list[int] = None,
     ) -> dict[str, dict[int, float]]:
@@ -432,7 +433,8 @@ class RAGPretrainedModel:
 
         Parameters:
             queries (list[str]): A list of queries to evaluate the model on.
-            expected_ids (list[list[tuple[str, Optional[int]]]): A list of lists of expected (document_id, passage_id) tuples for each query. Set passage_id to None if not applicable.
+            expected_document_ids (list[list[str]]): A list of lists of expected document IDs for each query.
+            expected_passage_ids (list[list[int]]): A list of lists of expected passage IDs for each query. Set to None if documents are not split into passages
             metrics (list[str]): A list of metrics to evaluate the model on. Valid metrics are "hit_rate", "recall", and "mrr".
             k (list[int]): The numbers of results to consider for each query in the evaluation.
 
@@ -443,4 +445,4 @@ class RAGPretrainedModel:
             k = [10]
         if not metrics:
             metrics = ["hit_rate", "recall", "mrr"]
-        return self.model.evaluate(queries, expected_ids, metrics, k)
+        return self.model.evaluate(queries, expected_document_ids, expected_passage_ids, metrics, k)

--- a/ragatouille/RAGPretrainedModel.py
+++ b/ragatouille/RAGPretrainedModel.py
@@ -420,3 +420,27 @@ class RAGPretrainedModel:
         self, k: int = 5, **kwargs: Any
     ) -> BaseDocumentCompressor:
         return RAGatouilleLangChainCompressor(model=self, k=k, kwargs=kwargs)
+
+    def evaluate(
+        self,
+        queries: list[str],
+        expected_ids: list[list[str]],
+        metrics: list[str] = None,
+        k: list[int] = None,
+    ) -> dict[str, dict[int, float]]:
+        """Evaluate the model on a set of queries.
+
+        Parameters:
+            queries (list[str]): A list of queries to evaluate the model on.
+            expected_ids (list[list[str]]): A list of lists of expected document IDs for each query.
+            metrics (list[str]): A list of metrics to evaluate the model on. Valid metrics are "hit_rate", "recall", and "mrr".
+            k (list[int]): The numbers of results to consider for each query in the evaluation.
+
+        Returns:
+            results (dict[str, dict[int, float]]): A nested dictionary containing the evaluation results for each metric and each k.
+        """
+        if not k:
+            k = [10]
+        if not metrics:
+            metrics = ["hit_rate", "recall", "mrr"]
+        return self.model.evaluate(queries, expected_ids, metrics, k)

--- a/ragatouille/RAGTrainer.py
+++ b/ragatouille/RAGTrainer.py
@@ -101,7 +101,7 @@ class RAGTrainer:
         """
         if all_documents is not None:
             self.collection += [doc for doc in all_documents if isinstance(doc, str)]
-
+        print(1)
         self.data_dir = Path(data_out_path)
         sample = raw_data[0]
         if len(sample) == 2:
@@ -115,7 +115,7 @@ class RAGTrainer:
                 data_type = "triplets"
         else:
             raise ValueError("Raw data must be a list of pairs or triplets of strings.")
-
+        print(2)
         self.queries = set()
         for x in raw_data:
             if isinstance(x[0], str):
@@ -130,20 +130,20 @@ class RAGTrainer:
 
         self.collection = list(set(self.collection))
         seeded_shuffle(self.collection)
-
+        print(3)
         if mine_hard_negatives:
             self.negative_miner = SimpleMiner(
                 language_code=self.language_code,
                 model_size=hard_negative_model_size,
             )
             self.negative_miner.build_index(self.collection)
-
+        print(4)
         self.data_processor = TrainingDataProcessor(
             collection=self.collection,
             queries=self.queries,
             negative_miner=self.negative_miner if mine_hard_negatives else None,
         )
-
+        print(5)
         self.data_processor.process_raw_data(
             data_type=data_type,
             raw_data=raw_data,
@@ -155,6 +155,7 @@ class RAGTrainer:
             mine_hard_negatives=mine_hard_negatives,
             hard_negative_minimum_rank=hard_negative_minimum_rank,
         )
+        print(6)
         if len(self.data_processor.training_triplets) == 0:
             if mine_hard_negatives:
                 print(
@@ -173,7 +174,7 @@ class RAGTrainer:
                 )
             else:
                 raise ValueError("No training triplets were generated.")
-
+        print(7)
         self.training_triplets = self.data_processor.training_triplets
 
         return data_out_path

--- a/ragatouille/evaluation/metrics.py
+++ b/ragatouille/evaluation/metrics.py
@@ -1,0 +1,96 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Type
+
+
+class BaseMetric(ABC):
+    """Base class for metrics."""
+
+    metric_name: str
+
+    @abstractmethod
+    def compute(
+        self,
+        expected_ids: Optional[List[str]] = None,
+        retrieved_ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> float:
+        """Compute metric.
+
+        Args:
+            expected_ids (Optional[List[str]]): Expected ids
+            retrieved_ids (Optional[List[str]]): Retrieved ids
+            **kwargs: Additional keyword arguments
+        """
+
+
+class HitRate(BaseMetric):
+    """Hit rate metric."""
+
+    metric_name: str = "hit_rate"
+
+    def compute(
+        self,
+        expected_ids: Optional[List[str]] = None,
+        retrieved_ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> float:
+        """Compute metric."""
+        if retrieved_ids is None or expected_ids is None:
+            raise ValueError("Retrieved ids and expected ids must be provided")
+        is_hit = any(id in expected_ids for id in retrieved_ids)
+        return 1.0 if is_hit else 0.0
+
+
+class Recall(BaseMetric):
+    """Recall metric."""
+
+    metric_name: str = "recall"
+
+    def compute(
+        self,
+        expected_ids: Optional[List[str]] = None,
+        retrieved_ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> float:
+        """Compute metric."""
+        if retrieved_ids is None or expected_ids is None:
+            raise ValueError("Retrieved ids and expected ids must be provided")
+        num_expected = len(expected_ids)
+        num_relevant = len(set(expected_ids) & set(retrieved_ids))
+        return num_relevant / num_expected if num_expected > 0 else 0.0
+
+
+class MRR(BaseMetric):
+    """MRR metric."""
+
+    metric_name: str = "mrr"
+
+    def compute(
+        self,
+        expected_ids: Optional[List[str]] = None,
+        retrieved_ids: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> float:
+        """Compute metric."""
+        if retrieved_ids is None or expected_ids is None:
+            raise ValueError("Retrieved ids and expected ids must be provided")
+        for i, id in enumerate(retrieved_ids):
+            if id in expected_ids:
+                return 1.0 / (i + 1)
+        return 0.0
+
+
+METRIC_REGISTRY: Dict[str, Type[BaseMetric]] = {
+    "hit_rate": HitRate,
+    "recall": Recall,
+    "mrr": MRR,
+}
+
+
+def resolve_metrics(metrics: List[str]) -> List[Type[BaseMetric]]:
+    """Resolve metrics from list of metric names."""
+    for metric in metrics:
+        if metric not in METRIC_REGISTRY:
+            raise ValueError(f"Invalid metric name: {metric}")
+
+    return [METRIC_REGISTRY[metric] for metric in metrics]

--- a/ragatouille/evaluation/metrics.py
+++ b/ragatouille/evaluation/metrics.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Tuple
 
 
 class BaseMetric(ABC):
@@ -10,15 +10,15 @@ class BaseMetric(ABC):
     @abstractmethod
     def compute(
         self,
-        expected_ids: Optional[List[str]] = None,
-        retrieved_ids: Optional[List[str]] = None,
+        expected_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
+        retrieved_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
         **kwargs: Any,
     ) -> float:
         """Compute metric.
 
         Args:
-            expected_ids (Optional[List[str]]): Expected ids
-            retrieved_ids (Optional[List[str]]): Retrieved ids
+            expected_ids (Optional[List[Tuple[str, Optional[int]]]]): Expected ids
+            retrieved_ids (Optional[List[Tuple[str, Optional[int]]]]): Retrieved ids
             **kwargs: Additional keyword arguments
         """
 
@@ -30,8 +30,8 @@ class HitRate(BaseMetric):
 
     def compute(
         self,
-        expected_ids: Optional[List[str]] = None,
-        retrieved_ids: Optional[List[str]] = None,
+        expected_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
+        retrieved_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
         **kwargs: Any,
     ) -> float:
         """Compute metric."""
@@ -48,8 +48,8 @@ class Recall(BaseMetric):
 
     def compute(
         self,
-        expected_ids: Optional[List[str]] = None,
-        retrieved_ids: Optional[List[str]] = None,
+        expected_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
+        retrieved_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
         **kwargs: Any,
     ) -> float:
         """Compute metric."""
@@ -67,8 +67,8 @@ class MRR(BaseMetric):
 
     def compute(
         self,
-        expected_ids: Optional[List[str]] = None,
-        retrieved_ids: Optional[List[str]] = None,
+        expected_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
+        retrieved_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
         **kwargs: Any,
     ) -> float:
         """Compute metric."""

--- a/ragatouille/evaluation/metrics.py
+++ b/ragatouille/evaluation/metrics.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Type, Tuple
+from typing import Any, Dict, List, Optional, Type, Tuple, Union
 
 
 class BaseMetric(ABC):
@@ -10,15 +10,15 @@ class BaseMetric(ABC):
     @abstractmethod
     def compute(
         self,
-        expected_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
-        retrieved_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
+        expected_ids: Optional[List[Union[str, Tuple[str, int]]]] = None,
+        retrieved_ids: Optional[List[Union[str, Tuple[str, int]]]] = None,
         **kwargs: Any,
     ) -> float:
         """Compute metric.
 
         Args:
-            expected_ids (Optional[List[Tuple[str, Optional[int]]]]): Expected ids
-            retrieved_ids (Optional[List[Tuple[str, Optional[int]]]]): Retrieved ids
+            expected_ids (Optional[List[Union[str, Tuple[str, int]]]]): Expected ids
+            retrieved_ids (Optional[List[Union[str, Tuple[str, int]]]]): Retrieved ids
             **kwargs: Additional keyword arguments
         """
 
@@ -30,8 +30,8 @@ class HitRate(BaseMetric):
 
     def compute(
         self,
-        expected_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
-        retrieved_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
+        expected_ids: Optional[List[Union[str, Tuple[str, int]]]] = None,
+        retrieved_ids: Optional[List[Union[str, Tuple[str, int]]]] = None,
         **kwargs: Any,
     ) -> float:
         """Compute metric."""
@@ -48,8 +48,8 @@ class Recall(BaseMetric):
 
     def compute(
         self,
-        expected_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
-        retrieved_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
+        expected_ids: Optional[List[Union[str, Tuple[str, int]]]] = None,
+        retrieved_ids: Optional[List[Union[str, Tuple[str, int]]]] = None,
         **kwargs: Any,
     ) -> float:
         """Compute metric."""
@@ -67,8 +67,8 @@ class MRR(BaseMetric):
 
     def compute(
         self,
-        expected_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
-        retrieved_ids: Optional[List[Tuple[str, Optional[int]]]] = None,
+        expected_ids: Optional[List[Union[str, Tuple[str, int]]]] = None,
+        retrieved_ids: Optional[List[Union[str, Tuple[str, int]]]] = None,
         **kwargs: Any,
     ) -> float:
         """Compute metric."""

--- a/ragatouille/models/base.py
+++ b/ragatouille/models/base.py
@@ -35,3 +35,12 @@ class LateInteractionModel(ABC):
     @abstractmethod
     def _batch_search(self, name: str, queries: list[str]):
         ...
+
+    @abstractmethod
+    def evaluate(
+        self,
+        queries: list[str],
+        expected_ids: list[list[str]],
+        metrics: list[str],
+        k: list[int],
+    ): ...

--- a/ragatouille/models/base.py
+++ b/ragatouille/models/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Union, Optional
+from typing import Union
 
 
 class LateInteractionModel(ABC):
@@ -39,7 +39,8 @@ class LateInteractionModel(ABC):
     def evaluate(
         self,
         queries: list[str],
-        expected_ids: list[list[tuple[str, Optional[int]]]],
+        expected_document_ids: list[list[str]],
+        expected_passage_ids: list[list[int]],
         metrics: list[str],
         k: list[int],
     ):

--- a/ragatouille/models/base.py
+++ b/ragatouille/models/base.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Union
+from typing import Union, Optional
 
 
 class LateInteractionModel(ABC):
@@ -9,8 +9,7 @@ class LateInteractionModel(ABC):
         self,
         pretrained_model_name_or_path: Union[str, Path],
         n_gpu,
-    ):
-        ...
+    ): ...
 
     @abstractmethod
     def train():
@@ -40,7 +39,8 @@ class LateInteractionModel(ABC):
     def evaluate(
         self,
         queries: list[str],
-        expected_ids: list[list[str]],
+        expected_ids: list[list[tuple[str, Optional[int]]]],
         metrics: list[str],
         k: list[int],
-    ): ...
+    ):
+        ...

--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -750,16 +750,18 @@ class ColBERT(LateInteractionModel):
     def evaluate(
         self,
         queries: list[str],
-        expected_ids: list[list[str]],
+        expected_ids: list[list[tuple[str, Optional[int]]]],
         metrics: list[str] = None,
         k: list[int] = None,
     ) -> dict[str, dict[int, float]]:
         search_results = self.search(queries, k=max(k))
+        if len(queries) == 1:
+            search_results = [search_results]
         sorted_search_results = [
             sorted(results, key=lambda x: x["rank"]) for results in search_results
         ]
         retrieved_ids = [
-            [result["document_id"] for result in results]
+            [(result["document_id"], result.get("passage_id", None)) for result in results]
             for results in sorted_search_results
         ]
 

--- a/ragatouille/negative_miners/simpleminer.py
+++ b/ragatouille/negative_miners/simpleminer.py
@@ -58,7 +58,9 @@ class SimpleMiner(HardNegativeMiner):
     ):
         print(f"Building hard negative index for {len(collection)} documents...")
         if len(collection) > 1000:
+            print(100)
             pool = self.model.start_multi_process_pool()
+            print(101)
             embeds = self.model.encode_multi_process(
                 collection, pool, batch_size=batch_size
             )

--- a/ragatouille/negative_miners/simpleminer.py
+++ b/ragatouille/negative_miners/simpleminer.py
@@ -64,7 +64,9 @@ class SimpleMiner(HardNegativeMiner):
             embeds = self.model.encode_multi_process(
                 collection, pool, batch_size=batch_size
             )
+            print(102)
             self.model.stop_multi_process_pool(pool)
+            print(103)
         else:
             embeds = self.model.encode(collection, batch_size=batch_size)
 

--- a/tests/e2e/test_e2e_indexing_evaluation.py
+++ b/tests/e2e/test_e2e_indexing_evaluation.py
@@ -1,0 +1,25 @@
+import srsly
+
+from ragatouille import RAGPretrainedModel
+
+
+def test_indexing():
+    RAG = RAGPretrainedModel.from_pretrained("colbert-ir/colbertv2.0")
+    with open("tests/data/miyazaki_wikipedia.txt", "r") as f:
+        full_document = f.read()
+    RAG.index(
+        collection=[full_document],
+        index_name="Miyazaki",
+        max_document_length=180,
+        split_documents=True,
+    )
+    # ensure collection is stored to disk
+    collection = srsly.read_json(
+        ".ragatouille/colbert/indexes/Miyazaki/collection.json"
+    )
+    assert len(collection) > 1
+
+
+def test_search():
+    RAG = RAGPretrainedModel.from_index(".ragatouille/colbert/indexes/Miyazaki/")
+    k = 3  # How many documents you want to retrieve, defaults to 10, we set it to 3 here for readability

--- a/tests/e2e/test_e2e_indexing_evaluation.py
+++ b/tests/e2e/test_e2e_indexing_evaluation.py
@@ -30,8 +30,9 @@ def test_evaluate():
     metrics = ["hit_rate", "recall", "mrr"]
     metric_dict = RAG.evaluate(
         ["What animation studio did Miyazaki found?"],
-        [[(result["document_id"], result["passage_id"]) for result in results[:3]]],
-        metrics,
+        [[result["document_id"] for result in results[:k]]],
+        [[result["passage_id"] for result in results[:k]]],
+        metrics=metrics,
         k=[k],
     )
 

--- a/tests/e2e/test_e2e_indexing_evaluation.py
+++ b/tests/e2e/test_e2e_indexing_evaluation.py
@@ -20,6 +20,20 @@ def test_indexing():
     assert len(collection) > 1
 
 
-def test_search():
+def test_evaluate():
     RAG = RAGPretrainedModel.from_index(".ragatouille/colbert/indexes/Miyazaki/")
-    k = 3  # How many documents you want to retrieve, defaults to 10, we set it to 3 here for readability
+    k = 3
+
+    results = RAG.search(query="What animation studio did Miyazaki found?", k=k)
+    assert len(results) == k
+
+    metrics = ["hit_rate", "recall", "mrr"]
+    metric_dict = RAG.evaluate(
+        ["What animation studio did Miyazaki found?"],
+        [[(result["document_id"], result["passage_id"]) for result in results[:3]]],
+        metrics,
+        k=[k],
+    )
+
+    for metric in metrics:
+        assert metric_dict[metric][k] == 1.0

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,124 @@
+import numpy as np
+
+from ragatouille.RAGPretrainedModel import RAGPretrainedModel
+
+
+def mock_search_results(
+    queries, search_results, model, expected_ids, metrics, k_values
+):
+    model.model.search = lambda queries, k: search_results
+    return model.evaluate(queries, expected_ids, metrics, k_values)
+
+
+def test_evaluate():
+    model = RAGPretrainedModel.from_pretrained("colbert-ir/colbertv2.0")
+
+    queries = ["query1", "query2"]
+    expected_ids = [
+        [("doc1", None), ("doc2", None), ("doc3", None)],
+        [("doc2", None), ("doc3", None), ("doc4", None)],
+    ]
+
+    metrics = ["recall", "hit_rate", "mrr"]
+    k_values = [1, 2, 3]
+
+    search_results1 = [
+        [
+            {"document_id": "doc1", "rank": 1},
+            {"document_id": "doc2", "rank": 2},
+            {"document_id": "doc3", "rank": 3},
+        ],
+        [
+            {"document_id": "doc2", "rank": 1},
+            {"document_id": "doc3", "rank": 2},
+            {"document_id": "doc4", "rank": 3},
+        ],
+    ]
+
+    result1 = mock_search_results(
+        queries, search_results1, model, expected_ids, metrics, k_values
+    )
+
+    expected_results1 = {
+        "recall": {1: 0.3333333333333333, 2: 0.6666666666666666, 3: 1.0},
+        "hit_rate": {
+            1: 1.0,
+            2: 1.0,
+            3: 1.0,
+        },
+        "mrr": {1: 1.0, 2: 1.0, 3: 1.0},
+    }
+
+    for metric_name, metric_data in result1.items():
+        for k, value in metric_data.items():
+            assert np.isclose(value, expected_results1[metric_name][k])
+
+    search_results2 = [
+        [
+            {"document_id": "doc1", "rank": 1},
+            {"document_id": "doc2", "rank": 2},
+            {"document_id": "doc3", "rank": 3},
+        ],
+        [
+            {"document_id": "doc5", "rank": 1},
+            {"document_id": "doc6", "rank": 2},
+            {"document_id": "doc7", "rank": 3},
+        ],
+    ]
+
+    result2 = mock_search_results(
+        queries, search_results2, model, expected_ids, metrics, k_values
+    )
+
+    expected_results2 = {
+        "recall": {1: 0.1666666666666666, 2: 0.3333333333333333, 3: 0.5},
+        "hit_rate": {
+            1: 0.5,
+            2: 0.5,
+            3: 0.5,
+        },
+        "mrr": {
+            1: 0.5,
+            2: 0.5,
+            3: 0.5,
+        },
+    }
+
+    for metric_name, metric_data in result2.items():
+        for k, value in metric_data.items():
+            assert np.isclose(value, expected_results2[metric_name][k])
+
+    search_results3 = [
+        [
+            {"document_id": "doc1",  "rank": 1},
+            {"document_id": "doc2",  "rank": 2},
+            {"document_id": "doc3",  "rank": 3},
+        ],
+        [
+            {"document_id": "doc6",  "rank": 1},
+            {"document_id": "doc5",  "rank": 2},
+            {"document_id": "doc4",  "rank": 3},
+        ],
+    ]
+
+    result3 = mock_search_results(
+        queries, search_results3, model, expected_ids, metrics, k_values
+    )
+
+    expected_results3 = {
+        "recall": {1: 0.1666666666666666, 2: 0.3333333333333333, 3: 0.6666666666666666},
+        "hit_rate": {
+            1: 0.5,
+            2: 0.5,
+            3: 1.0,
+        },
+        "mrr": {
+            1: 0.5,
+            2: 0.5,
+            3: 0.6666666666666666,
+        },
+    }
+
+    for metric_name, metric_data in result3.items():
+        for k, value in metric_data.items():
+            assert np.isclose(value, expected_results3[metric_name][k])

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -7,17 +7,14 @@ def mock_search_results(
     queries, search_results, model, expected_ids, metrics, k_values
 ):
     model.model.search = lambda queries, k: search_results
-    return model.evaluate(queries, expected_ids, metrics, k_values)
+    return model.evaluate(queries, expected_ids, metrics=metrics, k=k_values)
 
 
 def test_evaluate():
     model = RAGPretrainedModel.from_pretrained("colbert-ir/colbertv2.0")
 
     queries = ["query1", "query2"]
-    expected_ids = [
-        [("doc1", None), ("doc2", None), ("doc3", None)],
-        [("doc2", None), ("doc3", None), ("doc4", None)],
-    ]
+    expected_ids = [["doc1", "doc2", "doc3"], ["doc2", "doc3", "doc4"]]
 
     metrics = ["recall", "hit_rate", "mrr"]
     k_values = [1, 2, 3]
@@ -90,14 +87,14 @@ def test_evaluate():
 
     search_results3 = [
         [
-            {"document_id": "doc1",  "rank": 1},
-            {"document_id": "doc2",  "rank": 2},
-            {"document_id": "doc3",  "rank": 3},
+            {"document_id": "doc1", "rank": 1},
+            {"document_id": "doc2", "rank": 2},
+            {"document_id": "doc3", "rank": 3},
         ],
         [
-            {"document_id": "doc6",  "rank": 1},
-            {"document_id": "doc5",  "rank": 2},
-            {"document_id": "doc4",  "rank": 3},
+            {"document_id": "doc6", "rank": 1},
+            {"document_id": "doc5", "rank": 2},
+            {"document_id": "doc4", "rank": 3},
         ],
     ]
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,166 @@
+from ragatouille.evaluation.metrics import *
+
+
+def test_hit_rate():
+    hit_rate_metric = HitRate()
+
+    # Typical case: Both expected and retrieved IDs are provided, and at least one ID matches
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = [("2", None), ("5", None), ("6", None)]
+    assert hit_rate_metric.compute(expected_ids, retrieved_ids) == 1.0
+
+    # Typical case: Both expected and retrieved IDs are provided, but no match
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = [("5", None), ("6", None)]
+    assert hit_rate_metric.compute(expected_ids, retrieved_ids) == 0.0
+
+    # Edge case: Both lists are empty
+    expected_ids = []
+    retrieved_ids = []
+    assert hit_rate_metric.compute(expected_ids, retrieved_ids) == 0.0
+
+    # Edge case: No expected IDs provided
+    expected_ids = None
+    retrieved_ids = [("5", None), ("6", None)]
+    try:
+        hit_rate_metric.compute(expected_ids, retrieved_ids)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+    # Edge case: No retrieved IDs provided
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = None
+    try:
+        hit_rate_metric.compute(expected_ids, retrieved_ids)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+    # Edge case: Both lists are None
+    expected_ids = None
+    retrieved_ids = None
+    try:
+        hit_rate_metric.compute(expected_ids, retrieved_ids)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_recall():
+    recall_metric = Recall()
+
+    # Typical case: Both expected and retrieved IDs are provided
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = [("2", None), ("3", None), ("5", None), ("6", None)]
+    assert recall_metric.compute(expected_ids, retrieved_ids) == 2 / 4
+
+    # Edge case: Both lists are empty
+    expected_ids = []
+    retrieved_ids = []
+    assert recall_metric.compute(expected_ids, retrieved_ids) == 0.0
+
+    # Edge case: No relevant IDs retrieved
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = [("5", None), ("6", None), ("7", None), ("8", None)]
+    assert recall_metric.compute(expected_ids, retrieved_ids) == 0.0
+
+    # Edge case: No expected IDs provided
+    expected_ids = None
+    retrieved_ids = [("5", None), ("6", None), ("7", None), ("8", None)]
+    try:
+        recall_metric.compute(expected_ids, retrieved_ids)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+    # Edge case: No retrieved IDs provided
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = None
+    try:
+        recall_metric.compute(expected_ids, retrieved_ids)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+    # Edge case: Both lists are None
+    expected_ids = None
+    retrieved_ids = None
+    try:
+        recall_metric.compute(expected_ids, retrieved_ids)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_mrr():
+    mrr_metric = MRR()
+
+    # Typical case: Both expected and retrieved IDs are provided, and the first ID matches
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = [("2", None), ("5", None), ("6", None)]
+    assert mrr_metric.compute(expected_ids, retrieved_ids) == 1.0
+
+    # Typical case: Both expected and retrieved IDs are provided, and the second ID matches
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = [("5", None), ("2", None), ("6", None)]
+    assert mrr_metric.compute(expected_ids, retrieved_ids) == 0.5
+
+    # Typical case: Both expected and retrieved IDs are provided, but no match
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = [("5", None), ("6", None)]
+    assert mrr_metric.compute(expected_ids, retrieved_ids) == 0.0
+
+    # Edge case: Both lists are empty
+    expected_ids = []
+    retrieved_ids = []
+    assert mrr_metric.compute(expected_ids, retrieved_ids) == 0.0
+
+    # Edge case: No expected IDs provided
+    expected_ids = None
+    retrieved_ids = [("5", None), ("6", None)]
+    try:
+        mrr_metric.compute(expected_ids, retrieved_ids)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+    # Edge case: No retrieved IDs provided
+    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    retrieved_ids = None
+    try:
+        mrr_metric.compute(expected_ids, retrieved_ids)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+    # Edge case: Both lists are None
+    expected_ids = None
+    retrieved_ids = None
+    try:
+        mrr_metric.compute(expected_ids, retrieved_ids)
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_resolve_metrics():
+    # Test with valid metric names
+    valid_metrics = ["recall", "hit_rate", "mrr"]
+    resolved_metrics = resolve_metrics(valid_metrics)
+    assert len(resolved_metrics) == len(valid_metrics)
+    for metric, resolved_metric_class in zip(valid_metrics, resolved_metrics):
+        assert resolved_metric_class == METRIC_REGISTRY[metric]
+
+    # Test with invalid metric name
+    invalid_metric = ["invalid_metric"]
+    try:
+        resolve_metrics(invalid_metric)
+        assert False, "Expected ValueError for invalid metric name"
+    except ValueError:
+        pass
+
+    # Test with empty list of metrics
+    empty_metrics = []
+    resolved_empty_metrics = resolve_metrics(empty_metrics)
+    assert len(resolved_empty_metrics) == 0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,13 +5,13 @@ def test_hit_rate():
     hit_rate_metric = HitRate()
 
     # Typical case: Both expected and retrieved IDs are provided, and at least one ID matches
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
-    retrieved_ids = [("2", None), ("5", None), ("6", None)]
+    expected_ids = ["1", "2", "3", "4"]
+    retrieved_ids = ["2", "5", "6"]
     assert hit_rate_metric.compute(expected_ids, retrieved_ids) == 1.0
 
     # Typical case: Both expected and retrieved IDs are provided, but no match
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
-    retrieved_ids = [("5", None), ("6", None)]
+    expected_ids = ["1", "2", "3", "4"]
+    retrieved_ids = ["5", "6"]
     assert hit_rate_metric.compute(expected_ids, retrieved_ids) == 0.0
 
     # Edge case: Both lists are empty
@@ -21,7 +21,7 @@ def test_hit_rate():
 
     # Edge case: No expected IDs provided
     expected_ids = None
-    retrieved_ids = [("5", None), ("6", None)]
+    retrieved_ids = ["5", "6"]
     try:
         hit_rate_metric.compute(expected_ids, retrieved_ids)
         assert False, "Expected ValueError"
@@ -29,7 +29,7 @@ def test_hit_rate():
         pass
 
     # Edge case: No retrieved IDs provided
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    expected_ids = ["1", "2", "3", "4"]
     retrieved_ids = None
     try:
         hit_rate_metric.compute(expected_ids, retrieved_ids)
@@ -51,8 +51,8 @@ def test_recall():
     recall_metric = Recall()
 
     # Typical case: Both expected and retrieved IDs are provided
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
-    retrieved_ids = [("2", None), ("3", None), ("5", None), ("6", None)]
+    expected_ids = ["1", "2", "3", "4"]
+    retrieved_ids = ["2", "3", "5", "6"]
     assert recall_metric.compute(expected_ids, retrieved_ids) == 2 / 4
 
     # Edge case: Both lists are empty
@@ -61,13 +61,13 @@ def test_recall():
     assert recall_metric.compute(expected_ids, retrieved_ids) == 0.0
 
     # Edge case: No relevant IDs retrieved
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
-    retrieved_ids = [("5", None), ("6", None), ("7", None), ("8", None)]
+    expected_ids = ["1", "2", "3", "4"]
+    retrieved_ids = ["5", "6", "7", "8"]
     assert recall_metric.compute(expected_ids, retrieved_ids) == 0.0
 
     # Edge case: No expected IDs provided
     expected_ids = None
-    retrieved_ids = [("5", None), ("6", None), ("7", None), ("8", None)]
+    retrieved_ids = ["5", "6", "7", "8"]
     try:
         recall_metric.compute(expected_ids, retrieved_ids)
         assert False, "Expected ValueError"
@@ -75,7 +75,7 @@ def test_recall():
         pass
 
     # Edge case: No retrieved IDs provided
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    expected_ids = ["1", "2", "3", "4"]
     retrieved_ids = None
     try:
         recall_metric.compute(expected_ids, retrieved_ids)
@@ -97,18 +97,18 @@ def test_mrr():
     mrr_metric = MRR()
 
     # Typical case: Both expected and retrieved IDs are provided, and the first ID matches
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
-    retrieved_ids = [("2", None), ("5", None), ("6", None)]
+    expected_ids = ["1", "2", "3", "4"]
+    retrieved_ids = ["2", "5", "6"]
     assert mrr_metric.compute(expected_ids, retrieved_ids) == 1.0
 
     # Typical case: Both expected and retrieved IDs are provided, and the second ID matches
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
-    retrieved_ids = [("5", None), ("2", None), ("6", None)]
+    expected_ids = ["1", "2", "3", "4"]
+    retrieved_ids = ["5", "2", "6"]
     assert mrr_metric.compute(expected_ids, retrieved_ids) == 0.5
 
     # Typical case: Both expected and retrieved IDs are provided, but no match
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
-    retrieved_ids = [("5", None), ("6", None)]
+    expected_ids = ["1", "2", "3", "4"]
+    retrieved_ids = ["5", "6"]
     assert mrr_metric.compute(expected_ids, retrieved_ids) == 0.0
 
     # Edge case: Both lists are empty
@@ -118,7 +118,7 @@ def test_mrr():
 
     # Edge case: No expected IDs provided
     expected_ids = None
-    retrieved_ids = [("5", None), ("6", None)]
+    retrieved_ids = ["5", "6"]
     try:
         mrr_metric.compute(expected_ids, retrieved_ids)
         assert False, "Expected ValueError"
@@ -126,7 +126,7 @@ def test_mrr():
         pass
 
     # Edge case: No retrieved IDs provided
-    expected_ids = [("1", None), ("2", None), ("3", None), ("4", None)]
+    expected_ids = ["1", "2", "3", "4"]
     retrieved_ids = None
     try:
         mrr_metric.compute(expected_ids, retrieved_ids)


### PR DESCRIPTION
Adds an `evaluate` method to RAGPretrainedModel which evaluates the model given a list of queries and a list of expected document IDs to be retrieved by each query.

3 metrics are available for now: hit rate, recall and MRR.

Inspiration taken from [here](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/evaluation/retrieval/metrics.py).

Related issue: #107 