### PR TITLE
performance: Optimize ColBERT index free search with torch.topk

### DIFF
--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -476,10 +476,9 @@ class ColBERT(LateInteractionModel):
 
         for query in embedded_queries:
             results_for_query = []
-            scores = self._colbert_score(query, embedded_docs, doc_mask)
-            sorted_scores = sorted(enumerate(scores), key=lambda x: x[1], reverse=True)
-            high_score_idxes = [index for index, _ in sorted_scores[:k]]
-            for rank, doc_idx in enumerate(high_score_idxes):
+            scores = self._colbert_score(query, embedded_docs, doc_mask) # cpu
+            sorted_scores = torch.topk(scores, k)
+            for rank, doc_idx in enumerate(sorted_scores.indices.tolist()):
                 result = {
                     "content": documents[doc_idx],
                     "score": float(scores[doc_idx]),

--- a/ragatouille/models/colbert.py
+++ b/ragatouille/models/colbert.py
@@ -476,7 +476,7 @@ class ColBERT(LateInteractionModel):
 
         for query in embedded_queries:
             results_for_query = []
-            scores = self._colbert_score(query, embedded_docs, doc_mask) # cpu
+            scores = self._colbert_score(query, embedded_docs, doc_mask)
             sorted_scores = torch.topk(scores, k)
             for rank, doc_idx in enumerate(sorted_scores.indices.tolist()):
                 result = {


### PR DESCRIPTION
The following line is a bottleneck when using the index free search:

https://github.com/bclavie/RAGatouille/blob/796b49388cad0822564f30ef0b1464d021186637/ragatouille/models/colbert.py#L480

The change I introduce reduces the search time over 25k documents from 5.571s to 0.023s in my local setup with an intel i7 and a RTX 4090.


Script to reproduce:
```python
from ragatouille import RAGPretrainedModel
from datasets import load_dataset

# Load the pretrained model
r = RAGPretrainedModel.from_pretrained('colbert-ir/colbertv2.0')

# Load the dataset
dataset = load_dataset('mteb/scidocs', 'corpus')
docs = dataset['corpus']['text']
print(f"Number of documents: {len(docs)}")

# Encode the documents
encodings = r.encode(docs, bsize=256)

# Perform search on encoded documents
import timeit

def search():
    return r.search_encoded_docs('Recurrent Neural Networks', k=5)

# Timing the searches
rnn_time = timeit.timeit(search, number=7)

print(f"Search 'Recurrent Neural Networks': {rnn_time / 7:.3f} s per loop")
```
